### PR TITLE
Update neo4j base image

### DIFF
--- a/docker/debian.Dockerfile
+++ b/docker/debian.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_BUILDER_IMAGE=centos:8.4.2105
+ARG BASE_BUILDER_IMAGE=registry.access.redhat.com/ubi8/ubi:8.4-213
 ARG BASE_NEO4J_IMAGE=neo4j:4.2.3
 
 #####


### PR DESCRIPTION
Removed use of centos base image for neo4j plugin to (by default) use ubi8, specifically ubi8's latest 8.4 image.