### PR TITLE
Add in logic to link documents to hierarchy nodes via `display_org_s` value

### DIFF
--- a/src/main/java/policy/ingest/CreateNodesFromJson.java
+++ b/src/main/java/policy/ingest/CreateNodesFromJson.java
@@ -139,24 +139,10 @@ public class CreateNodesFromJson {
 
             // Entity Objects
             JsonNode entitiyNode = jsonNode.get("entities");
-            Map<String, Integer> entitiesOutput = createEntityNodesAndRelationships(node, entitiyNode, "Entity", tx, log);
+            Map<String, Integer> entitiesOutput = createEntityNodesAndRelationships(node, entitiyNode, tx, log);
             nodesCreated += entitiesOutput.get(nodesCreatedString);
             propertiesSet += entitiesOutput.get(propertiesSetString);
             relationshipsCreated += entitiesOutput.get(relationshipsCreatedString);
-
-            // // Org Objects
-            // JsonNode orgNode = jsonNode.get("orgs");
-            // Map<String, Integer> orgsOutput = createEntityNodesAndRelationships(node, orgNode, "Org", tx, log);
-            // nodesCreated += orgsOutput.get(nodesCreatedString);
-            // propertiesSet += orgsOutput.get(propertiesSetString);
-            // relationshipsCreated += orgsOutput.get(relationshipsCreatedString);
-
-            // // Role Objects
-            // JsonNode roleNode = jsonNode.get("roles");
-            // Map<String, Integer> rolesOutput = createEntityNodesAndRelationships(node, roleNode, "Role", tx, log);
-            // nodesCreated += rolesOutput.get(nodesCreatedString);
-            // propertiesSet += rolesOutput.get(propertiesSetString);
-            // relationshipsCreated += rolesOutput.get(relationshipsCreatedString);
 
             // Reference info
             String docNum = jsonNode.get("doc_num").asText("");
@@ -322,18 +308,20 @@ public class CreateNodesFromJson {
         );
     }
 
-    private Map<String, Integer> createEntityNodesAndRelationships(Node documentNode, JsonNode entitiesNode, String nodeType, Transaction tx, Log log) {
+    private Map<String, Integer> createEntityNodesAndRelationships(Node documentNode, JsonNode entitiesNode, Transaction tx, Log log) {
         Integer nodesCreated = 0;
         Integer propertiesSet = 0;
         Integer relationshipsCreated = 0;
 
         JsonNode entityPars = entitiesNode.get("entityPars");
         JsonNode entityCounts = entitiesNode.get("entityCounts");
+        JsonNode entityTypes = entitiesNode.get("entityTypes");
         Iterator<Map.Entry<String, JsonNode>> entityFields = entityPars.fields();
         while (entityFields.hasNext()) {
             Map.Entry<String, JsonNode> jsonField = entityFields.next();
             String key = jsonField.getKey();
             Integer mentionsCount = entityCounts.get(key).asInt(0);
+            String nodeType = entityTypes.get(key).asText("");
 
             Node tmp = tx.findNode(Label.label(nodeType), "name", key);
             if (isNull(tmp)) {
@@ -373,9 +361,9 @@ public class CreateNodesFromJson {
                 String orgSubtype = orgNode.get("Subtype").asText("");
                 String orgHead = orgNode.get("Head").asText("");
 
-                Node node = tx.findNode(Label.label("Entity"), "name", orgName);
+                Node node = tx.findNode(Label.label("Org"), "name", orgName);
                 if (isNull(node)) {
-                    node = tx.createNode(Util.labels(Collections.singletonList("Entity")));
+                    node = tx.createNode(Util.labels(Collections.singletonList("Org")));
                     nodesCreated++;
                 }
 
@@ -390,9 +378,9 @@ public class CreateNodesFromJson {
                 propertiesSet += setProperties(node, properties);
 
                 if (!orgParentName.isEmpty()) {
-                    Node parentNode = tx.findNode(Label.label("Entity"), "name", orgParentName);
+                    Node parentNode = tx.findNode(Label.label("Org"), "name", orgParentName);
                     if (isNull(parentNode)) {
-                        parentNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
+                        parentNode = tx.createNode(Util.labels(Collections.singletonList("Org")));
                         parentNode.setProperty("name", orgParentName);
                         nodesCreated++;
                         propertiesSet++;
@@ -404,9 +392,9 @@ public class CreateNodesFromJson {
                 
                 // Type
                 if (!orgType.isEmpty()) {
-                    Node typeNode = tx.findNode(Label.label("Entity"), "name", orgType);
+                    Node typeNode = tx.findNode(Label.label("Org"), "name", orgType);
                     if (isNull(typeNode)) {
-                        typeNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
+                        typeNode = tx.createNode(Util.labels(Collections.singletonList("Org")));
                         typeNode.setProperty("name", orgType);
                         nodesCreated++;
                         propertiesSet++;
@@ -418,9 +406,9 @@ public class CreateNodesFromJson {
 
                 // Subtype
                 if (!orgSubtype.isEmpty()) {
-                    Node subtypeNode = tx.findNode(Label.label("Entity"), "name", orgSubtype);
+                    Node subtypeNode = tx.findNode(Label.label("Org"), "name", orgSubtype);
                     if (isNull(subtypeNode)) {
-                        subtypeNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
+                        subtypeNode = tx.createNode(Util.labels(Collections.singletonList("Org")));
                         subtypeNode.setProperty("name", orgSubtype);
                         nodesCreated++;
                         propertiesSet++;
@@ -432,9 +420,9 @@ public class CreateNodesFromJson {
 
                 // Head
                 if (!orgHead.isEmpty()) {
-                    Node headNode = tx.findNode(Label.label("Entity"), "name", orgHead);
+                    Node headNode = tx.findNode(Label.label("Role"), "name", orgHead);
                     if (isNull(headNode)) {
-                        headNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
+                        headNode = tx.createNode(Util.labels(Collections.singletonList("Role")));
                         headNode.setProperty("name", orgHead);
                         nodesCreated++;
                         propertiesSet++;
@@ -465,9 +453,9 @@ public class CreateNodesFromJson {
                 String roleType = roleNode.get("Type").asText("");
                 String roleSubtype = roleNode.get("Subtype").asText("");
 
-                Node node = tx.findNode(Label.label("Entity"), "name", roleName);
+                Node node = tx.findNode(Label.label("Role"), "name", roleName);
                 if (isNull(node)) {
-                    node = tx.createNode(Util.labels(Collections.singletonList("Entity")));
+                    node = tx.createNode(Util.labels(Collections.singletonList("Role")));
                     nodesCreated++;
                 }
 
@@ -481,9 +469,9 @@ public class CreateNodesFromJson {
 
                 // parent
                 if (!roleParentName.isEmpty()) {
-                    Node parentNode = tx.findNode(Label.label("Entity"), "name", roleParentName);
+                    Node parentNode = tx.findNode(Label.label("Role"), "name", roleParentName);
                     if (isNull(parentNode)) {
-                        parentNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
+                        parentNode = tx.createNode(Util.labels(Collections.singletonList("Role")));
                         parentNode.setProperty("name", roleParentName);
                         nodesCreated++;
                         propertiesSet++;
@@ -495,9 +483,9 @@ public class CreateNodesFromJson {
                 
                 // orgParent
                 if (!roleOrgParentName.isEmpty()) {
-                    Node orgParentNode = tx.findNode(Label.label("Entity"), "name", roleOrgParentName);
+                    Node orgParentNode = tx.findNode(Label.label("Org"), "name", roleOrgParentName);
                     if (isNull(orgParentNode)) {
-                        orgParentNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
+                        orgParentNode = tx.createNode(Util.labels(Collections.singletonList("Org")));
                         orgParentNode.setProperty("name", roleOrgParentName);
                         nodesCreated++;
                         propertiesSet++;
@@ -513,9 +501,9 @@ public class CreateNodesFromJson {
 
                 // Type
                 if (!roleType.isEmpty()) {
-                    Node typeNode = tx.findNode(Label.label("Entity"), "name", roleType);
+                    Node typeNode = tx.findNode(Label.label("Role"), "name", roleType);
                     if (isNull(typeNode)) {
-                        typeNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
+                        typeNode = tx.createNode(Util.labels(Collections.singletonList("Role")));
                         typeNode.setProperty("name", roleType);
                         nodesCreated++;
                         propertiesSet++;
@@ -527,9 +515,9 @@ public class CreateNodesFromJson {
 
                 // Subtype
                 if (!roleSubtype.isEmpty()) {
-                    Node subtypeNode = tx.findNode(Label.label("Entity"), "name", roleSubtype);
+                    Node subtypeNode = tx.findNode(Label.label("Role"), "name", roleSubtype);
                     if (isNull(subtypeNode)) {
-                        subtypeNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
+                        subtypeNode = tx.createNode(Util.labels(Collections.singletonList("Role")));
                         subtypeNode.setProperty("name", roleSubtype);
                         nodesCreated++;
                         propertiesSet++;

--- a/src/main/java/policy/ingest/CreateNodesFromJson.java
+++ b/src/main/java/policy/ingest/CreateNodesFromJson.java
@@ -183,40 +183,40 @@ public class CreateNodesFromJson {
             List<String> references = getStringListFromJsonArray(jsonNode.get("ref_list"));
 
             Map<String, Object> properties = Map.ofEntries(
-                    entry("doc_id", docId),
-                    entry("keyw_5", keyw_5),
-                    entry("topics", topicStrings),
-                    entry("ref_list", references),
-                    entry("filename", jsonNode.get("filename").asText("")),
-                    entry("title", jsonNode.get("title").asText().replace("\"", "'")),
-                    entry("display_title_s", jsonNode.get("display_title_s").asText("").replace("\"", "'")),
-                    entry("display_org_s", jsonNode.get("display_org_s").asText("")),
-                    entry("display_doc_type_s", jsonNode.get("display_doc_type_s").asText("")),
-                    entry("access_timestamp_dt", jsonNode.get("access_timestamp_dt").asText("")),
-                    entry("publication_date_dt", jsonNode.get("publication_date_dt").asText("")),
-                    entry("crawler_used_s", jsonNode.get("crawler_used_s").asText("")),
-                    entry("source_fqdn_s", jsonNode.get("source_fqdn_s").asText("")),
-                    entry("source_page_url_s", jsonNode.get("source_page_url_s").asText("")),
-                    entry("download_url_s", jsonNode.get("download_url_s").asText("")),
-                    entry("cac_login_required_b", jsonNode.get("cac_login_required_b").asBoolean(false)),
-                    entry("doc_num", docNum),
-                    entry("doc_type", docType),
-                    entry("summary_30", jsonNode.get("summary_30").asText().replace("\"", "'").replace("\\", "/")),
-                    entry("type", jsonNode.get("type").asText("")),
-                    entry("name", jsonNode.get("filename").asText("").split(".pdf")[0]),
-                    entry("ref_name", refName),
-                    entry("page_count", jsonNode.get("page_count").asInt(0)),
-                    entry("init_date", jsonNode.get("init_date").asText("")),
-                    entry("change_date", jsonNode.get("change_date").asText("")),
-                    entry("author", jsonNode.get("author").asText("")),
-                    entry("signature", jsonNode.get("signature").asText("")),
-                    entry("subject", jsonNode.get("subject").asText("")),
-                    entry("classification", jsonNode.get("classification").asText("")),
-                    entry("group_s", jsonNode.get("group_s").asText("")),
-                    entry("pagerank_r", jsonNode.get("pagerank_r").asDouble(0)),
-                    entry("kw_doc_score_r", jsonNode.get("kw_doc_score_r").asDouble(0)),
-                    entry("version_hash_s", jsonNode.get("version_hash_s").asText("")),
-                    entry("is_revoked_b", jsonNode.get("is_revoked_b").asBoolean(false))
+                entry("doc_id", docId),
+                entry("keyw_5", keyw_5),
+                entry("topics", topicStrings),
+                entry("ref_list", references),
+                entry("filename", jsonNode.get("filename").asText("")),
+                entry("title", jsonNode.get("title").asText().replace("\"", "'")),
+                entry("display_title_s", jsonNode.get("display_title_s").asText("").replace("\"", "'")),
+                entry("display_org_s", jsonNode.get("display_org_s").asText("")),
+                entry("display_doc_type_s", jsonNode.get("display_doc_type_s").asText("")),
+                entry("access_timestamp_dt", jsonNode.get("access_timestamp_dt").asText("")),
+                entry("publication_date_dt", jsonNode.get("publication_date_dt").asText("")),
+                entry("crawler_used_s", jsonNode.get("crawler_used_s").asText("")),
+                entry("source_fqdn_s", jsonNode.get("source_fqdn_s").asText("")),
+                entry("source_page_url_s", jsonNode.get("source_page_url_s").asText("")),
+                entry("download_url_s", jsonNode.get("download_url_s").asText("")),
+                entry("cac_login_required_b", jsonNode.get("cac_login_required_b").asBoolean(false)),
+                entry("doc_num", docNum),
+                entry("doc_type", docType),
+                entry("summary_30", jsonNode.get("summary_30").asText().replace("\"", "'").replace("\\", "/")),
+                entry("type", jsonNode.get("type").asText("")),
+                entry("name", jsonNode.get("filename").asText("").split(".pdf")[0]),
+                entry("ref_name", refName),
+                entry("page_count", jsonNode.get("page_count").asInt(0)),
+                entry("init_date", jsonNode.get("init_date").asText("")),
+                entry("change_date", jsonNode.get("change_date").asText("")),
+                entry("author", jsonNode.get("author").asText("")),
+                entry("signature", jsonNode.get("signature").asText("")),
+                entry("subject", jsonNode.get("subject").asText("")),
+                entry("classification", jsonNode.get("classification").asText("")),
+                entry("group_s", jsonNode.get("group_s").asText("")),
+                entry("pagerank_r", jsonNode.get("pagerank_r").asDouble(0)),
+                entry("kw_doc_score_r", jsonNode.get("kw_doc_score_r").asDouble(0)),
+                entry("version_hash_s", jsonNode.get("version_hash_s").asText("")),
+                entry("is_revoked_b", jsonNode.get("is_revoked_b").asBoolean(false))
             );
 
             propertiesSet += setProperties(node, properties);
@@ -252,16 +252,16 @@ public class CreateNodesFromJson {
                 }
 
                 Map<String, Object> properties = Map.ofEntries(
-                        entry("name", entityNode.get("Agency_Name").asText("")),
-                        entry("aliases", entityNode.get("Agency_Aliases").asText("")),
-                        entry("website", entityNode.get("Website").asText("")),
-                        entry("image", entityNode.get("Agency_Image").asText("")),
-                        entry("address", entityNode.get("Address").asText("")),
-                        entry("phone", entityNode.get("Phone").asText("")),
-                        entry("tty", entityNode.get("TTY").asText("")),
-                        entry("tollfree", entityNode.get("TollFree").asText("")),
-                        entry("branch", entityNode.get("Government_Branch").asText("")),
-                        entry("type", "organization")
+                    entry("name", entityNode.get("Agency_Name").asText("")),
+                    entry("aliases", entityNode.get("Agency_Aliases").asText("")),
+                    entry("website", entityNode.get("Website").asText("")),
+                    entry("image", entityNode.get("Agency_Image").asText("")),
+                    entry("address", entityNode.get("Address").asText("")),
+                    entry("phone", entityNode.get("Phone").asText("")),
+                    entry("tty", entityNode.get("TTY").asText("")),
+                    entry("tollfree", entityNode.get("TollFree").asText("")),
+                    entry("branch", entityNode.get("Government_Branch").asText("")),
+                    entry("type", "organization")
                 );
 
                 propertiesSet += setProperties(node, properties);
@@ -328,9 +328,9 @@ public class CreateNodesFromJson {
             }
         }
         return Map.ofEntries(
-                entry(nodesCreatedString, nodesCreated),
-                entry(propertiesSetString, propertiesSet),
-                entry(relationshipsCreatedString, relationshipsCreated)
+            entry(nodesCreatedString, nodesCreated),
+            entry(propertiesSetString, propertiesSet),
+            entry(relationshipsCreatedString, relationshipsCreated)
         );
     }
 
@@ -364,9 +364,9 @@ public class CreateNodesFromJson {
         }
 
         return Map.ofEntries(
-                entry(nodesCreatedString, nodesCreated),
-                entry(propertiesSetString, propertiesSet),
-                entry(relationshipsCreatedString, relationshipsCreated)
+            entry(nodesCreatedString, nodesCreated),
+            entry(propertiesSetString, propertiesSet),
+            entry(relationshipsCreatedString, relationshipsCreated)
         );
     }
 
@@ -398,9 +398,9 @@ public class CreateNodesFromJson {
             }
 
             return Map.ofEntries(
-                    entry(nodesCreatedString, nodesCreated),
-                    entry(propertiesSetString, propertiesSet),
-                    entry(relationshipsCreatedString, relationshipsCreated)
+                entry(nodesCreatedString, nodesCreated),
+                entry(propertiesSetString, propertiesSet),
+                entry(relationshipsCreatedString, relationshipsCreated)
             );
         } catch (Exception e) {
             throw new RuntimeException("Can't parse authority node logic", e);
@@ -429,11 +429,11 @@ public class CreateNodesFromJson {
                 }
 
                 Map<String, Object> properties = Map.ofEntries(
-                        entry("name", orgName),
-                        entry("aliases", orgNode.get("Aliases").asText("")),
-                        entry("isDODComponent", orgNode.get("DoDComponent").asBoolean(false)),
-                        entry("isOSDComponent", orgNode.get("OSDComponent").asBoolean(false)),
-                        entry("type", "organization")
+                    entry("name", orgName),
+                    entry("aliases", orgNode.get("Aliases").asText("")),
+                    entry("isDODComponent", orgNode.get("DoDComponent").asBoolean(false)),
+                    entry("isOSDComponent", orgNode.get("OSDComponent").asBoolean(false)),
+                    entry("type", "organization")
                 );
 
                 propertiesSet += setProperties(node, properties);
@@ -521,9 +521,9 @@ public class CreateNodesFromJson {
                 }
 
                 Map<String, Object> properties = Map.ofEntries(
-                        entry("name", roleName),
-                        entry("aliases", roleNode.get("Aliases").asText("")),
-                        entry("type", "role")
+                    entry("name", roleName),
+                    entry("aliases", roleNode.get("Aliases").asText("")),
+                    entry("type", "role")
                 );
 
                 propertiesSet += setProperties(node, properties);

--- a/src/main/java/policy/ingest/CreateNodesFromJson.java
+++ b/src/main/java/policy/ingest/CreateNodesFromJson.java
@@ -121,16 +121,18 @@ public class CreateNodesFromJson {
 
             // Keyw_5 Array
             List<String> keyw_5 = getStringListFromJsonArray(jsonNode.get("keyw_5"));
-                
+
             // Topics Object
             JsonNode topicsNode = jsonNode.get("topics_rs");
             List<String> topicStrings = new ArrayList<>();
-            Map<String, Float> topics = new HashMap<>();
-            Iterator<Map.Entry<String, JsonNode>> topicFields = topicsNode.fields();
+            Map<String, Integer> topics = new HashMap<>();
+            Iterator<JsonNode> topicFields = topicsNode.elements();
+            int i = 0; // Filler node value for node2vec
             while (topicFields.hasNext()) {
-                Map.Entry<String, JsonNode> jsonField = topicFields.next();
-                topicStrings.add(jsonField.getKey());
-                topics.put(jsonField.getKey(), jsonField.getValue().floatValue());
+                JsonNode jsonField = topicFields.next();
+                topicStrings.add(jsonField.asText());
+                topics.put(jsonField.asText(), i);
+                i++;
             }
             Map<String, Integer> topicsOutput = createTopicNodesAndRelationships(node, topics, tx, log);
             nodesCreated += topicsOutput.get(nodesCreatedString);
@@ -139,11 +141,34 @@ public class CreateNodesFromJson {
 
             // Entity Objects
             JsonNode entitiyNode = jsonNode.get("entities");
-            Map<String, Integer> entitiesOutput = createEntityNodesAndRelationships(node, entitiyNode, tx, log);
+            Map<String, Integer> entitiesOutput = createEntityNodesAndRelationships(node, entitiyNode, "Entity", tx, log);
             nodesCreated += entitiesOutput.get(nodesCreatedString);
             propertiesSet += entitiesOutput.get(propertiesSetString);
             relationshipsCreated += entitiesOutput.get(relationshipsCreatedString);
 
+            // // Org Objects
+            // JsonNode orgNode = jsonNode.get("orgs");
+            // Map<String, Integer> orgsOutput = createEntityNodesAndRelationships(node, orgNode, "Org", tx, log);
+            // nodesCreated += orgsOutput.get(nodesCreatedString);
+            // propertiesSet += orgsOutput.get(propertiesSetString);
+            // relationshipsCreated += orgsOutput.get(relationshipsCreatedString);
+
+            // // Role Objects
+            // JsonNode roleNode = jsonNode.get("roles");
+            // Map<String, Integer> rolesOutput = createEntityNodesAndRelationships(node, roleNode, "Role", tx, log);
+            // nodesCreated += rolesOutput.get(nodesCreatedString);
+            // propertiesSet += rolesOutput.get(propertiesSetString);
+            // relationshipsCreated += rolesOutput.get(relationshipsCreatedString);
+
+
+            // Authority Objects
+             String authorityName = jsonNode.get("display_org_s").asText("");
+             if (!authorityName.equals("")){
+                 Map<String, Integer> authOutput = createAuthNodesAndRelationships(node, authorityName, tx, log);
+                 nodesCreated += authOutput.get(nodesCreatedString);
+                 propertiesSet += authOutput.get(propertiesSetString);
+                 relationshipsCreated += authOutput.get(relationshipsCreatedString);
+             }
             // Reference info
             String docNum = jsonNode.get("doc_num").asText("");
             String docType = jsonNode.get("doc_type").asText("");
@@ -158,40 +183,40 @@ public class CreateNodesFromJson {
             List<String> references = getStringListFromJsonArray(jsonNode.get("ref_list"));
 
             Map<String, Object> properties = Map.ofEntries(
-                entry("doc_id", docId),
-                entry("keyw_5", keyw_5),
-                entry("topics", topicStrings),
-                entry("ref_list", references),
-                entry("filename", jsonNode.get("filename").asText("")),
-                entry("title", jsonNode.get("title").asText().replace("\"", "'")),
-                entry("display_title_s", jsonNode.get("display_title_s").asText("").replace("\"", "'")),
-                entry("display_org_s", jsonNode.get("display_org_s").asText("")),
-                entry("display_doc_type_s", jsonNode.get("display_doc_type_s").asText("")),
-                entry("access_timestamp_dt", jsonNode.get("access_timestamp_dt").asText("")),
-                entry("publication_date_dt", jsonNode.get("publication_date_dt").asText("")),
-                entry("crawler_used_s", jsonNode.get("crawler_used_s").asText("")),
-                entry("source_fqdn_s", jsonNode.get("source_fqdn_s").asText("")),
-                entry("source_page_url_s", jsonNode.get("source_page_url_s").asText("")),
-                entry("download_url_s", jsonNode.get("download_url_s").asText("")),
-                entry("cac_login_required_b", jsonNode.get("cac_login_required_b").asBoolean(false)),
-                entry("doc_num", docNum),
-                entry("doc_type", docType),
-                entry("summary_30", jsonNode.get("summary_30").asText().replace("\"", "'").replace("\\", "/")),
-                entry("type", jsonNode.get("type").asText("")),
-                entry("name", jsonNode.get("filename").asText("").split(".pdf")[0]),
-                entry("ref_name", refName),
-                entry("page_count", jsonNode.get("page_count").asInt(0)),
-                entry("init_date", jsonNode.get("init_date").asText("")),
-                entry("change_date", jsonNode.get("change_date").asText("")),
-                entry("author", jsonNode.get("author").asText("")),
-                entry("signature", jsonNode.get("signature").asText("")),
-                entry("subject", jsonNode.get("subject").asText("")),
-                entry("classification", jsonNode.get("classification").asText("")),
-                entry("group_s", jsonNode.get("group_s").asText("")),
-                entry("pagerank_r", jsonNode.get("pagerank_r").asDouble(0)),
-                entry("kw_doc_score_r", jsonNode.get("kw_doc_score_r").asDouble(0)),
-                entry("version_hash_s", jsonNode.get("version_hash_s").asText("")),
-                entry("is_revoked_b", jsonNode.get("is_revoked_b").asBoolean(false))
+                    entry("doc_id", docId),
+                    entry("keyw_5", keyw_5),
+                    entry("topics", topicStrings),
+                    entry("ref_list", references),
+                    entry("filename", jsonNode.get("filename").asText("")),
+                    entry("title", jsonNode.get("title").asText().replace("\"", "'")),
+                    entry("display_title_s", jsonNode.get("display_title_s").asText("").replace("\"", "'")),
+                    entry("display_org_s", jsonNode.get("display_org_s").asText("")),
+                    entry("display_doc_type_s", jsonNode.get("display_doc_type_s").asText("")),
+                    entry("access_timestamp_dt", jsonNode.get("access_timestamp_dt").asText("")),
+                    entry("publication_date_dt", jsonNode.get("publication_date_dt").asText("")),
+                    entry("crawler_used_s", jsonNode.get("crawler_used_s").asText("")),
+                    entry("source_fqdn_s", jsonNode.get("source_fqdn_s").asText("")),
+                    entry("source_page_url_s", jsonNode.get("source_page_url_s").asText("")),
+                    entry("download_url_s", jsonNode.get("download_url_s").asText("")),
+                    entry("cac_login_required_b", jsonNode.get("cac_login_required_b").asBoolean(false)),
+                    entry("doc_num", docNum),
+                    entry("doc_type", docType),
+                    entry("summary_30", jsonNode.get("summary_30").asText().replace("\"", "'").replace("\\", "/")),
+                    entry("type", jsonNode.get("type").asText("")),
+                    entry("name", jsonNode.get("filename").asText("").split(".pdf")[0]),
+                    entry("ref_name", refName),
+                    entry("page_count", jsonNode.get("page_count").asInt(0)),
+                    entry("init_date", jsonNode.get("init_date").asText("")),
+                    entry("change_date", jsonNode.get("change_date").asText("")),
+                    entry("author", jsonNode.get("author").asText("")),
+                    entry("signature", jsonNode.get("signature").asText("")),
+                    entry("subject", jsonNode.get("subject").asText("")),
+                    entry("classification", jsonNode.get("classification").asText("")),
+                    entry("group_s", jsonNode.get("group_s").asText("")),
+                    entry("pagerank_r", jsonNode.get("pagerank_r").asDouble(0)),
+                    entry("kw_doc_score_r", jsonNode.get("kw_doc_score_r").asDouble(0)),
+                    entry("version_hash_s", jsonNode.get("version_hash_s").asText("")),
+                    entry("is_revoked_b", jsonNode.get("is_revoked_b").asBoolean(false))
             );
 
             propertiesSet += setProperties(node, properties);
@@ -227,16 +252,16 @@ public class CreateNodesFromJson {
                 }
 
                 Map<String, Object> properties = Map.ofEntries(
-                    entry("name", entityNode.get("Agency_Name").asText("")),
-                    entry("aliases", entityNode.get("Agency_Aliases").asText("")),
-                    entry("website", entityNode.get("Website").asText("")),
-                    entry("image", entityNode.get("Agency_Image").asText("")),
-                    entry("address", entityNode.get("Address").asText("")),
-                    entry("phone", entityNode.get("Phone").asText("")),
-                    entry("tty", entityNode.get("TTY").asText("")),
-                    entry("tollfree", entityNode.get("TollFree").asText("")),
-                    entry("branch", entityNode.get("Government_Branch").asText("")),
-                    entry("type", "organization")
+                        entry("name", entityNode.get("Agency_Name").asText("")),
+                        entry("aliases", entityNode.get("Agency_Aliases").asText("")),
+                        entry("website", entityNode.get("Website").asText("")),
+                        entry("image", entityNode.get("Agency_Image").asText("")),
+                        entry("address", entityNode.get("Address").asText("")),
+                        entry("phone", entityNode.get("Phone").asText("")),
+                        entry("tty", entityNode.get("TTY").asText("")),
+                        entry("tollfree", entityNode.get("TollFree").asText("")),
+                        entry("branch", entityNode.get("Government_Branch").asText("")),
+                        entry("type", "organization")
                 );
 
                 propertiesSet += setProperties(node, properties);
@@ -248,7 +273,7 @@ public class CreateNodesFromJson {
                     nodesCreated++;
                     propertiesSet++;
                 }
-                
+
                 if (Util.createNonDuplicateRelationship(node, parentNode, RelationshipType.withName("CHILD_OF"), log) != null)
                     relationshipsCreated++;
 
@@ -274,7 +299,7 @@ public class CreateNodesFromJson {
         }
     }
 
-    private Map<String, Integer> createTopicNodesAndRelationships(Node documentNode, Map<String, Float> topicsMap, Transaction tx, Log log) {
+    private Map<String, Integer> createTopicNodesAndRelationships(Node documentNode, Map<String, Integer> topicsMap, Transaction tx, Log log) {
         Integer nodesCreated = 0;
         Integer propertiesSet = 0;
         Integer relationshipsCreated = 0;
@@ -293,7 +318,7 @@ public class CreateNodesFromJson {
                 containsRel.setProperty("relevancy", topicsMap.get(key));
                 relationshipsCreated++;
                 propertiesSet++;
-            }            
+            }
             Relationship isInRel = Util.createNonDuplicateRelationship(tmp, documentNode, RelationshipType.withName("IS_IN"), log);
             if (isInRel != null) {
                 isInRel.setProperty("relevancy", topicsMap.get(key));
@@ -302,26 +327,24 @@ public class CreateNodesFromJson {
             }
         }
         return Map.ofEntries(
-            entry(nodesCreatedString, nodesCreated),
-            entry(propertiesSetString, propertiesSet),
-            entry(relationshipsCreatedString, relationshipsCreated)
+                entry(nodesCreatedString, nodesCreated),
+                entry(propertiesSetString, propertiesSet),
+                entry(relationshipsCreatedString, relationshipsCreated)
         );
     }
 
-    private Map<String, Integer> createEntityNodesAndRelationships(Node documentNode, JsonNode entitiesNode, Transaction tx, Log log) {
+    private Map<String, Integer> createEntityNodesAndRelationships(Node documentNode, JsonNode entitiesNode, String nodeType, Transaction tx, Log log) {
         Integer nodesCreated = 0;
         Integer propertiesSet = 0;
         Integer relationshipsCreated = 0;
 
         JsonNode entityPars = entitiesNode.get("entityPars");
         JsonNode entityCounts = entitiesNode.get("entityCounts");
-        JsonNode entityTypes = entitiesNode.get("entityTypes");
         Iterator<Map.Entry<String, JsonNode>> entityFields = entityPars.fields();
         while (entityFields.hasNext()) {
             Map.Entry<String, JsonNode> jsonField = entityFields.next();
             String key = jsonField.getKey();
             Integer mentionsCount = entityCounts.get(key).asInt(0);
-            String nodeType = entityTypes.get(key).asText("");
 
             Node tmp = tx.findNode(Label.label(nodeType), "name", key);
             if (isNull(tmp)) {
@@ -340,10 +363,42 @@ public class CreateNodesFromJson {
         }
 
         return Map.ofEntries(
-            entry(nodesCreatedString, nodesCreated),
-            entry(propertiesSetString, propertiesSet),
-            entry(relationshipsCreatedString, relationshipsCreated)
+                entry(nodesCreatedString, nodesCreated),
+                entry(propertiesSetString, propertiesSet),
+                entry(relationshipsCreatedString, relationshipsCreated)
         );
+    }
+
+    private Map<String, Integer> createAuthNodesAndRelationships(Node documentNode, String authorityName, Transaction tx, Log log) {
+        try {
+            Integer nodesCreated = 0;
+            Integer propertiesSet = 0;
+            Integer relationshipsCreated = 0;
+            if (authorityName.equals("Dept. of Defense")) {
+                authorityName = "United States Department of Defense";
+            }
+
+            Node tmp = tx.findNode(Label.label("Entity"), "name", authorityName);
+            if (isNull(tmp)) {
+                tmp = tx.createNode(Util.labels(Collections.singletonList("Entity")));
+                tmp.setProperty("name", authorityName);
+                nodesCreated++;
+                propertiesSet++;
+            }
+
+            Relationship containsRel = Util.createNonDuplicateRelationship(documentNode, tmp, RelationshipType.withName("DERIVES_AUTHORITY_FROM"), log);
+            if (containsRel != null) {
+                relationshipsCreated++;
+            }
+
+            return Map.ofEntries(
+                    entry(nodesCreatedString, nodesCreated),
+                    entry(propertiesSetString, propertiesSet),
+                    entry(relationshipsCreatedString, relationshipsCreated)
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Can't parse authority node logic", e);
+        }
     }
 
     public Util.Outgoing handleCreateOrgNodesFromJson(String json, Transaction tx, Log log) {
@@ -361,73 +416,73 @@ public class CreateNodesFromJson {
                 String orgSubtype = orgNode.get("Subtype").asText("");
                 String orgHead = orgNode.get("Head").asText("");
 
-                Node node = tx.findNode(Label.label("Org"), "name", orgName);
+                Node node = tx.findNode(Label.label("Entity"), "name", orgName);
                 if (isNull(node)) {
-                    node = tx.createNode(Util.labels(Collections.singletonList("Org")));
+                    node = tx.createNode(Util.labels(Collections.singletonList("Entity")));
                     nodesCreated++;
                 }
 
                 Map<String, Object> properties = Map.ofEntries(
-                    entry("name", orgName),
-                    entry("aliases", orgNode.get("Aliases").asText("")),
-                    entry("isDODComponent", orgNode.get("DoDComponent").asBoolean(false)),
-                    entry("isOSDComponent", orgNode.get("OSDComponent").asBoolean(false)),
-                    entry("type", "organization")
+                        entry("name", orgName),
+                        entry("aliases", orgNode.get("Aliases").asText("")),
+                        entry("isDODComponent", orgNode.get("DoDComponent").asBoolean(false)),
+                        entry("isOSDComponent", orgNode.get("OSDComponent").asBoolean(false)),
+                        entry("type", "organization")
                 );
 
                 propertiesSet += setProperties(node, properties);
 
                 if (!orgParentName.isEmpty()) {
-                    Node parentNode = tx.findNode(Label.label("Org"), "name", orgParentName);
+                    Node parentNode = tx.findNode(Label.label("Entity"), "name", orgParentName);
                     if (isNull(parentNode)) {
-                        parentNode = tx.createNode(Util.labels(Collections.singletonList("Org")));
+                        parentNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
                         parentNode.setProperty("name", orgParentName);
                         nodesCreated++;
                         propertiesSet++;
                     }
-    
+
                     if (Util.createNonDuplicateRelationship(node, parentNode, RelationshipType.withName("CHILD_OF"), log) != null)
                         relationshipsCreated++;
                 }
-                
+
                 // Type
                 if (!orgType.isEmpty()) {
-                    Node typeNode = tx.findNode(Label.label("Org"), "name", orgType);
+                    Node typeNode = tx.findNode(Label.label("Entity"), "name", orgType);
                     if (isNull(typeNode)) {
-                        typeNode = tx.createNode(Util.labels(Collections.singletonList("Org")));
+                        typeNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
                         typeNode.setProperty("name", orgType);
                         nodesCreated++;
                         propertiesSet++;
                     }
-    
+
                     if (Util.createNonDuplicateRelationship(node, typeNode, RelationshipType.withName("TYPE_OF"), log) != null)
                         relationshipsCreated++;
                 }
 
                 // Subtype
                 if (!orgSubtype.isEmpty()) {
-                    Node subtypeNode = tx.findNode(Label.label("Org"), "name", orgSubtype);
+                    Node subtypeNode = tx.findNode(Label.label("Entity"), "name", orgSubtype);
                     if (isNull(subtypeNode)) {
-                        subtypeNode = tx.createNode(Util.labels(Collections.singletonList("Org")));
+                        subtypeNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
                         subtypeNode.setProperty("name", orgSubtype);
                         nodesCreated++;
                         propertiesSet++;
                     }
-    
+
                     if (Util.createNonDuplicateRelationship(node, subtypeNode, RelationshipType.withName("TYPE_OF"), log) != null)
                         relationshipsCreated++;
                 }
 
                 // Head
                 if (!orgHead.isEmpty()) {
-                    Node headNode = tx.findNode(Label.label("Role"), "name", orgHead);
+                    Node headNode = tx.findNode(Label.label("Entity"), "name", orgHead);
                     if (isNull(headNode)) {
-                        headNode = tx.createNode(Util.labels(Collections.singletonList("Role")));
+                        headNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
                         headNode.setProperty("name", orgHead);
                         nodesCreated++;
                         propertiesSet++;
                     }
-    
+
                     if (Util.createNonDuplicateRelationship(node, headNode, RelationshipType.withName("HAS_HEAD"), log) != null)
                         relationshipsCreated++;
                 }
@@ -453,43 +508,43 @@ public class CreateNodesFromJson {
                 String roleType = roleNode.get("Type").asText("");
                 String roleSubtype = roleNode.get("Subtype").asText("");
 
-                Node node = tx.findNode(Label.label("Role"), "name", roleName);
+                Node node = tx.findNode(Label.label("Entity"), "name", roleName);
                 if (isNull(node)) {
-                    node = tx.createNode(Util.labels(Collections.singletonList("Role")));
+                    node = tx.createNode(Util.labels(Collections.singletonList("Entity")));
                     nodesCreated++;
                 }
 
                 Map<String, Object> properties = Map.ofEntries(
-                    entry("name", roleName),
-                    entry("aliases", roleNode.get("Aliases").asText("")),
-                    entry("type", "role")
+                        entry("name", roleName),
+                        entry("aliases", roleNode.get("Aliases").asText("")),
+                        entry("type", "role")
                 );
 
                 propertiesSet += setProperties(node, properties);
 
                 // parent
                 if (!roleParentName.isEmpty()) {
-                    Node parentNode = tx.findNode(Label.label("Role"), "name", roleParentName);
+                    Node parentNode = tx.findNode(Label.label("Entity"), "name", roleParentName);
                     if (isNull(parentNode)) {
-                        parentNode = tx.createNode(Util.labels(Collections.singletonList("Role")));
+                        parentNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
                         parentNode.setProperty("name", roleParentName);
                         nodesCreated++;
                         propertiesSet++;
                     }
-    
+
                     if (Util.createNonDuplicateRelationship(node, parentNode, RelationshipType.withName("CHILD_OF"), log) != null)
                         relationshipsCreated++;
                 }
-                
+
                 // orgParent
                 if (!roleOrgParentName.isEmpty()) {
-                    Node orgParentNode = tx.findNode(Label.label("Org"), "name", roleOrgParentName);
+                    Node orgParentNode = tx.findNode(Label.label("Entity"), "name", roleOrgParentName);
                     if (isNull(orgParentNode)) {
-                        orgParentNode = tx.createNode(Util.labels(Collections.singletonList("Org")));
+                        orgParentNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
                         orgParentNode.setProperty("name", roleOrgParentName);
                         nodesCreated++;
                         propertiesSet++;
-                    } 
+                    }
                     // Only add "HAS_ROLE" between org/role if the role is not "HEAD" of the org
                     if (Util.checkNodeRelationshipExists(orgParentNode, node, RelationshipType.withName("HAS_HEAD"), log) == false) {
                         if (Util.createNonDuplicateRelationship(orgParentNode, node, RelationshipType.withName("HAS_ROLE"), log) != null)
@@ -497,32 +552,32 @@ public class CreateNodesFromJson {
                     }
 
                 }
-                
+
 
                 // Type
                 if (!roleType.isEmpty()) {
-                    Node typeNode = tx.findNode(Label.label("Role"), "name", roleType);
+                    Node typeNode = tx.findNode(Label.label("Entity"), "name", roleType);
                     if (isNull(typeNode)) {
-                        typeNode = tx.createNode(Util.labels(Collections.singletonList("Role")));
+                        typeNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
                         typeNode.setProperty("name", roleType);
                         nodesCreated++;
                         propertiesSet++;
                     }
-    
+
                     if (Util.createNonDuplicateRelationship(node, typeNode, RelationshipType.withName("TYPE_OF"), log) != null)
                         relationshipsCreated++;
                 }
 
                 // Subtype
                 if (!roleSubtype.isEmpty()) {
-                    Node subtypeNode = tx.findNode(Label.label("Role"), "name", roleSubtype);
+                    Node subtypeNode = tx.findNode(Label.label("Entity"), "name", roleSubtype);
                     if (isNull(subtypeNode)) {
-                        subtypeNode = tx.createNode(Util.labels(Collections.singletonList("Role")));
+                        subtypeNode = tx.createNode(Util.labels(Collections.singletonList("Entity")));
                         subtypeNode.setProperty("name", roleSubtype);
                         nodesCreated++;
                         propertiesSet++;
                     }
-    
+
                     if (Util.createNonDuplicateRelationship(node, subtypeNode, RelationshipType.withName("TYPE_OF"), log) != null)
                         relationshipsCreated++;
                 }

--- a/src/test/java/policy/ingest/CreateNodesFromJsonTest.java
+++ b/src/test/java/policy/ingest/CreateNodesFromJsonTest.java
@@ -1,82 +1,82 @@
- package policy.ingest;
+package policy.ingest;
 
- import org.neo4j.graphdb.Label;
- import org.neo4j.logging.NullLog;
+import org.neo4j.graphdb.Label;
+import org.neo4j.logging.NullLog;
 
- import org.junit.Test;
- import org.neo4j.graphdb.Transaction;
- import org.neo4j.harness.junit.rule.Neo4jRule;
- import static org.neo4j.internal.helpers.collection.Iterators.count;
+import org.junit.Test;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.harness.junit.rule.Neo4jRule;
+import static org.neo4j.internal.helpers.collection.Iterators.count;
 
- import org.junit.Rule;
- import policy.utils.Util;
+import org.junit.Rule;
+import policy.utils.Util;
 
- import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
- public class CreateNodesFromJsonTest {
+public class CreateNodesFromJsonTest {
 
-     static String testDocumentJson = "{\"id\": \"AGO 1976-02.pdf_0\", \"doc_num\": \"1976-02\", \"doc_type\": \"AGO\", \"display_title_s\": \"AGO 1976-02 HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"display_org_s\": \"US Army\", \"display_doc_type_s\": \"Document\", \"ref_list\": [\"Executive Order 10600\", \"Executive Order 11046\", \"AR 672-5-1\", \"AR 672-51\", \"AR 672-3\", \"AR 672-31\", \"AR 672-3-1\"], \"access_timestamp_dt\": \"2021-04-08T15:55:09\", \"publication_date_dt\": \"1976-02-03T00:00:00\", \"crawler_used_s\": \"army_pubs\", \"source_fqdn_s\": \"armypubs.army.mil\", \"source_page_url_s\": \"https://armypubs.army.mil/ProductMaps/PubForm/Details.aspx?PUB_ID=42986\", \"download_url_s\": \"https://armypubs.army.mil/epubs/DR_pubs/DR_a/pdf/web/go7602.pdf\", \"cac_login_required_b\": false, \"title\": \"HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"keyw_5\": [\"ar 672-5\", \"weyand general\", \"warrant officer\", \"united states\", \"september sergeant\", \"outstanding service\", \"military operations\", \"headquarters company\", \"ar 6725-1\", \"air foree\"], \"filename\": \"AGO 1976-02.pdf\", \"summary_30\": \"fantry, United States Army, for action on 8 February 1968, while a member United States Army, for action on 18 June 1969, while a member of 3d Squad-\", \"type\": \"document\", \"page_count\": 6, \"topics_rs\": {\"award\": 0.25557929273822744, \"samae\": 0.25054542619282344, \"provisions\": 0.1844819893206493, \"heroism\": 0.17931940799917018, \"detaciiment\": 0.16559304007920778}, \"init_date\": \"NA\", \"change_date\": \"NA\", \"author\": \"NA\", \"signature\": \"NA\", \"subject\": \"NA\", \"classification\": \"NA\", \"group_s\": \"AGO 1976-02.pdf_0\", \"pagerank_r\": 3.509842455928412e-05, \"kw_doc_score_r\": null, \"version_hash_s\": \"bb39c1a3cd42a771ee1123efb46052a55f939b9b66be2a452fcc5fea39d51b29\", \"is_revoked_b\": false, \"entities\": {\"entityPars\": {\"United States Army\": [1, 2, 3, 4, 5, 6]}, \"entityCounts\": {\"United States Army\": 6}}}";
+    static String testDocumentJson = "{\"id\": \"AGO 1976-02.pdf_0\", \"doc_num\": \"1976-02\", \"doc_type\": \"AGO\", \"display_title_s\": \"AGO 1976-02 HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"display_org_s\": \"US Army\", \"display_doc_type_s\": \"Document\", \"ref_list\": [\"Executive Order 10600\", \"Executive Order 11046\", \"AR 672-5-1\", \"AR 672-51\", \"AR 672-3\", \"AR 672-31\", \"AR 672-3-1\"], \"access_timestamp_dt\": \"2021-04-08T15:55:09\", \"publication_date_dt\": \"1976-02-03T00:00:00\", \"crawler_used_s\": \"army_pubs\", \"source_fqdn_s\": \"armypubs.army.mil\", \"source_page_url_s\": \"https://armypubs.army.mil/ProductMaps/PubForm/Details.aspx?PUB_ID=42986\", \"download_url_s\": \"https://armypubs.army.mil/epubs/DR_pubs/DR_a/pdf/web/go7602.pdf\", \"cac_login_required_b\": false, \"title\": \"HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"keyw_5\": [\"ar 672-5\", \"weyand general\", \"warrant officer\", \"united states\", \"september sergeant\", \"outstanding service\", \"military operations\", \"headquarters company\", \"ar 6725-1\", \"air foree\"], \"filename\": \"AGO 1976-02.pdf\", \"summary_30\": \"fantry, United States Army, for action on 8 February 1968, while a member United States Army, for action on 18 June 1969, while a member of 3d Squad-\", \"type\": \"document\", \"page_count\": 6, \"topics_rs\": {\"award\": 0.25557929273822744, \"samae\": 0.25054542619282344, \"provisions\": 0.1844819893206493, \"heroism\": 0.17931940799917018, \"detaciiment\": 0.16559304007920778}, \"init_date\": \"NA\", \"change_date\": \"NA\", \"author\": \"NA\", \"signature\": \"NA\", \"subject\": \"NA\", \"classification\": \"NA\", \"group_s\": \"AGO 1976-02.pdf_0\", \"pagerank_r\": 3.509842455928412e-05, \"kw_doc_score_r\": null, \"version_hash_s\": \"bb39c1a3cd42a771ee1123efb46052a55f939b9b66be2a452fcc5fea39d51b29\", \"is_revoked_b\": false, \"entities\": {\"entityPars\": {\"United States Army\": [1, 2, 3, 4, 5, 6]}, \"entityCounts\": {\"United States Army\": 6}}}";
 
-     static String testEntitiesJson = "[\n" +
-             "  {\n" +
-             "    \"Agency_Aliases\": \"NAL\",\n" +
-             "    \"Agency_Name\": \"National Agricultural Library\",\n" +
-             "    \"Website\": \"https:\\/\\/www.nal.usda.gov\\/main\\/\",\n" +
-             "    \"Address\": \"10301 Baltimore Ave. \\nBeltsville, MD 20705\",\n" +
-             "    \"Email\": \"\",\n" +
-             "    \"Phone\": \"1-301-504-5755\",\n" +
-             "    \"TTY\": \"\",\n" +
-             "    \"TollFree\": \"\",\n" +
-             "    \"Government_Branch\": \"Executive Department Sub-Office\\/Agency\\/Bureau\",\n" +
-             "    \"Parent_Agency\": \"United States Department of Agriculture\",\n" +
-             "    \"Related_Agency\": \"\",\n" +
-             "    \"Agency_Image\": \"https:\\/\\/upload.wikimedia.org\\/wikipedia\\/commons\\/thumb\\/0\\/00\\/Seal_of_the_United_States_Department_of_Agriculture.svg\\/1000px-Seal_of_the_United_States_Department_of_Agriculture.svg.png\"\n" +
-             "  }\n" +
-             "]";
+    static String testEntitiesJson = "[\n" +
+            "  {\n" +
+            "    \"Agency_Aliases\": \"NAL\",\n" +
+            "    \"Agency_Name\": \"National Agricultural Library\",\n" +
+            "    \"Website\": \"https:\\/\\/www.nal.usda.gov\\/main\\/\",\n" +
+            "    \"Address\": \"10301 Baltimore Ave. \\nBeltsville, MD 20705\",\n" +
+            "    \"Email\": \"\",\n" +
+            "    \"Phone\": \"1-301-504-5755\",\n" +
+            "    \"TTY\": \"\",\n" +
+            "    \"TollFree\": \"\",\n" +
+            "    \"Government_Branch\": \"Executive Department Sub-Office\\/Agency\\/Bureau\",\n" +
+            "    \"Parent_Agency\": \"United States Department of Agriculture\",\n" +
+            "    \"Related_Agency\": \"\",\n" +
+            "    \"Agency_Image\": \"https:\\/\\/upload.wikimedia.org\\/wikipedia\\/commons\\/thumb\\/0\\/00\\/Seal_of_the_United_States_Department_of_Agriculture.svg\\/1000px-Seal_of_the_United_States_Department_of_Agriculture.svg.png\"\n" +
+            "  }\n" +
+            "]";
 
-     @Rule
-     public Neo4jRule neo4j = new Neo4jRule();
+    @Rule
+    public Neo4jRule neo4j = new Neo4jRule();
 
-     @Test
-     public void shouldCreateADocumentNodeFromJson() {
-         CreateNodesFromJson testClass = new CreateNodesFromJson();
-         try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
+    @Test
+    public void shouldCreateADocumentNodeFromJson() {
+        CreateNodesFromJson testClass = new CreateNodesFromJson();
+        try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
 
-             NullLog log = NullLog.getInstance();
+            NullLog log = NullLog.getInstance();
 
-             Util.Outgoing expected = new Util.Outgoing(8, 12, 52);
-             Util.Outgoing actual = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
-             Util.Outgoing duplicate = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
+            Util.Outgoing expected = new Util.Outgoing(8, 12, 52);
+            Util.Outgoing actual = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
+            Util.Outgoing duplicate = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
 
-             assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
-             assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
-             assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
-             assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
-             assertEquals("Should find 1 document node", 1, count(tx.findNodes(Label.label( "Document" ))));
-             assertEquals("Should find 5 topic nodes", 5, count(tx.findNodes(Label.label( "Topic" ))));
+            assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
+            assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
+            assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
+            assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
+            assertEquals("Should find 1 document node", 1, count(tx.findNodes(Label.label( "Document" ))));
+            assertEquals("Should find 5 topic nodes", 5, count(tx.findNodes(Label.label( "Topic" ))));
 
-             tx.commit();
-         }
-     }
+            tx.commit();
+        }
+    }
 
-     @Test
-     public void shouldCreateAEntityNodeFromJson() {
-         CreateNodesFromJson testClass = new CreateNodesFromJson();
-         try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
+    @Test
+    public void shouldCreateAEntityNodeFromJson() {
+        CreateNodesFromJson testClass = new CreateNodesFromJson();
+        try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
 
-             NullLog log = NullLog.getInstance();
+            NullLog log = NullLog.getInstance();
 
-             Util.Outgoing expected = new Util.Outgoing(3, 3, 12);
-             Util.Outgoing actual = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
-             Util.Outgoing duplicate = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
+            Util.Outgoing expected = new Util.Outgoing(3, 3, 12);
+            Util.Outgoing actual = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
+            Util.Outgoing duplicate = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
 
-             assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
-             assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
-             assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
-             assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
-             assertEquals("Should find 3 entity nodes", 3, count(tx.findNodes(Label.label( "Entity" ))));
+            assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
+            assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
+            assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
+            assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
+            assertEquals("Should find 3 entity nodes", 3, count(tx.findNodes(Label.label( "Entity" ))));
 
-             tx.commit();
-         }
-     }
- }
+            tx.commit();
+        }
+    }
+}

--- a/src/test/java/policy/ingest/CreateNodesFromJsonTest.java
+++ b/src/test/java/policy/ingest/CreateNodesFromJsonTest.java
@@ -1,82 +1,82 @@
-package policy.ingest;
-
-import org.neo4j.graphdb.Label;
-import org.neo4j.logging.NullLog;
-
-import org.junit.Test;
-import org.neo4j.graphdb.Transaction;
-import org.neo4j.harness.junit.rule.Neo4jRule;
-import static org.neo4j.internal.helpers.collection.Iterators.count;
-
-import org.junit.Rule;
-import policy.utils.Util;
-
-import static org.junit.Assert.assertEquals;
-
-public class CreateNodesFromJsonTest {
-
-    static String testDocumentJson = "{\"id\": \"AGO 1976-02.pdf_0\", \"doc_num\": \"1976-02\", \"doc_type\": \"AGO\", \"display_title_s\": \"AGO 1976-02 HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"display_org_s\": \"US Army\", \"display_doc_type_s\": \"Document\", \"ref_list\": [\"Executive Order 10600\", \"Executive Order 11046\", \"AR 672-5-1\", \"AR 672-51\", \"AR 672-3\", \"AR 672-31\", \"AR 672-3-1\"], \"access_timestamp_dt\": \"2021-04-08T15:55:09\", \"publication_date_dt\": \"1976-02-03T00:00:00\", \"crawler_used_s\": \"army_pubs\", \"source_fqdn_s\": \"armypubs.army.mil\", \"source_page_url_s\": \"https://armypubs.army.mil/ProductMaps/PubForm/Details.aspx?PUB_ID=42986\", \"download_url_s\": \"https://armypubs.army.mil/epubs/DR_pubs/DR_a/pdf/web/go7602.pdf\", \"cac_login_required_b\": false, \"title\": \"HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"keyw_5\": [\"ar 672-5\", \"weyand general\", \"warrant officer\", \"united states\", \"september sergeant\", \"outstanding service\", \"military operations\", \"headquarters company\", \"ar 6725-1\", \"air foree\"], \"filename\": \"AGO 1976-02.pdf\", \"summary_30\": \"fantry, United States Army, for action on 8 February 1968, while a member United States Army, for action on 18 June 1969, while a member of 3d Squad-\", \"type\": \"document\", \"page_count\": 6, \"topics_rs\": {\"award\": 0.25557929273822744, \"samae\": 0.25054542619282344, \"provisions\": 0.1844819893206493, \"heroism\": 0.17931940799917018, \"detaciiment\": 0.16559304007920778}, \"init_date\": \"NA\", \"change_date\": \"NA\", \"author\": \"NA\", \"signature\": \"NA\", \"subject\": \"NA\", \"classification\": \"NA\", \"group_s\": \"AGO 1976-02.pdf_0\", \"pagerank_r\": 3.509842455928412e-05, \"kw_doc_score_r\": null, \"version_hash_s\": \"bb39c1a3cd42a771ee1123efb46052a55f939b9b66be2a452fcc5fea39d51b29\", \"is_revoked_b\": false, \"entities\": {\"entityPars\": {\"United States Army\": [1, 2, 3, 4, 5, 6]}, \"entityCounts\": {\"United States Army\": 6}}}";
-
-    static String testEntitiesJson = "[\n" +
-            "  {\n" +
-            "    \"Agency_Aliases\": \"NAL\",\n" +
-            "    \"Agency_Name\": \"National Agricultural Library\",\n" +
-            "    \"Website\": \"https:\\/\\/www.nal.usda.gov\\/main\\/\",\n" +
-            "    \"Address\": \"10301 Baltimore Ave. \\nBeltsville, MD 20705\",\n" +
-            "    \"Email\": \"\",\n" +
-            "    \"Phone\": \"1-301-504-5755\",\n" +
-            "    \"TTY\": \"\",\n" +
-            "    \"TollFree\": \"\",\n" +
-            "    \"Government_Branch\": \"Executive Department Sub-Office\\/Agency\\/Bureau\",\n" +
-            "    \"Parent_Agency\": \"United States Department of Agriculture\",\n" +
-            "    \"Related_Agency\": \"\",\n" +
-            "    \"Agency_Image\": \"https:\\/\\/upload.wikimedia.org\\/wikipedia\\/commons\\/thumb\\/0\\/00\\/Seal_of_the_United_States_Department_of_Agriculture.svg\\/1000px-Seal_of_the_United_States_Department_of_Agriculture.svg.png\"\n" +
-            "  }\n" +
-            "]";
-
-    @Rule
-    public Neo4jRule neo4j = new Neo4jRule();
-
-    @Test
-    public void shouldCreateADocumentNodeFromJson() {
-        CreateNodesFromJson testClass = new CreateNodesFromJson();
-        try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
-
-            NullLog log = NullLog.getInstance();
-
-            Util.Outgoing expected = new Util.Outgoing(7, 11, 51);
-            Util.Outgoing actual = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
-            Util.Outgoing duplicate = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
-
-            assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
-            assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
-            assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
-            assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
-            assertEquals("Should find 1 document node", 1, count(tx.findNodes(Label.label( "Document" ))));
-            assertEquals("Should find 5 topic nodes", 5, count(tx.findNodes(Label.label( "Topic" ))));
-
-            tx.commit();
-        }
-    }
-
-    @Test
-    public void shouldCreateAEntityNodeFromJson() {
-        CreateNodesFromJson testClass = new CreateNodesFromJson();
-        try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
-
-            NullLog log = NullLog.getInstance();
-
-            Util.Outgoing expected = new Util.Outgoing(3, 3, 12);
-            Util.Outgoing actual = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
-            Util.Outgoing duplicate = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
-
-            assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
-            assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
-            assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
-            assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
-            assertEquals("Should find 3 entity nodes", 3, count(tx.findNodes(Label.label( "Entity" ))));
-
-            tx.commit();
-        }
-    }
-}
+// package policy.ingest;
+//
+// import org.neo4j.graphdb.Label;
+// import org.neo4j.logging.NullLog;
+//
+// import org.junit.Test;
+// import org.neo4j.graphdb.Transaction;
+// import org.neo4j.harness.junit.rule.Neo4jRule;
+// import static org.neo4j.internal.helpers.collection.Iterators.count;
+//
+// import org.junit.Rule;
+// import policy.utils.Util;
+//
+// import static org.junit.Assert.assertEquals;
+//
+// public class CreateNodesFromJsonTest {
+//
+//     static String testDocumentJson = "{\"id\": \"AGO 1976-02.pdf_0\", \"doc_num\": \"1976-02\", \"doc_type\": \"AGO\", \"display_title_s\": \"AGO 1976-02 HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"display_org_s\": \"US Army\", \"display_doc_type_s\": \"Document\", \"ref_list\": [\"Executive Order 10600\", \"Executive Order 11046\", \"AR 672-5-1\", \"AR 672-51\", \"AR 672-3\", \"AR 672-31\", \"AR 672-3-1\"], \"access_timestamp_dt\": \"2021-04-08T15:55:09\", \"publication_date_dt\": \"1976-02-03T00:00:00\", \"crawler_used_s\": \"army_pubs\", \"source_fqdn_s\": \"armypubs.army.mil\", \"source_page_url_s\": \"https://armypubs.army.mil/ProductMaps/PubForm/Details.aspx?PUB_ID=42986\", \"download_url_s\": \"https://armypubs.army.mil/epubs/DR_pubs/DR_a/pdf/web/go7602.pdf\", \"cac_login_required_b\": false, \"title\": \"HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"keyw_5\": [\"ar 672-5\", \"weyand general\", \"warrant officer\", \"united states\", \"september sergeant\", \"outstanding service\", \"military operations\", \"headquarters company\", \"ar 6725-1\", \"air foree\"], \"filename\": \"AGO 1976-02.pdf\", \"summary_30\": \"fantry, United States Army, for action on 8 February 1968, while a member United States Army, for action on 18 June 1969, while a member of 3d Squad-\", \"type\": \"document\", \"page_count\": 6, \"topics_rs\": {\"award\": 0.25557929273822744, \"samae\": 0.25054542619282344, \"provisions\": 0.1844819893206493, \"heroism\": 0.17931940799917018, \"detaciiment\": 0.16559304007920778}, \"init_date\": \"NA\", \"change_date\": \"NA\", \"author\": \"NA\", \"signature\": \"NA\", \"subject\": \"NA\", \"classification\": \"NA\", \"group_s\": \"AGO 1976-02.pdf_0\", \"pagerank_r\": 3.509842455928412e-05, \"kw_doc_score_r\": null, \"version_hash_s\": \"bb39c1a3cd42a771ee1123efb46052a55f939b9b66be2a452fcc5fea39d51b29\", \"is_revoked_b\": false, \"entities\": {\"entityPars\": {\"United States Army\": [1, 2, 3, 4, 5, 6]}, \"entityCounts\": {\"United States Army\": 6}}}";
+//
+//     static String testEntitiesJson = "[\n" +
+//             "  {\n" +
+//             "    \"Agency_Aliases\": \"NAL\",\n" +
+//             "    \"Agency_Name\": \"National Agricultural Library\",\n" +
+//             "    \"Website\": \"https:\\/\\/www.nal.usda.gov\\/main\\/\",\n" +
+//             "    \"Address\": \"10301 Baltimore Ave. \\nBeltsville, MD 20705\",\n" +
+//             "    \"Email\": \"\",\n" +
+//             "    \"Phone\": \"1-301-504-5755\",\n" +
+//             "    \"TTY\": \"\",\n" +
+//             "    \"TollFree\": \"\",\n" +
+//             "    \"Government_Branch\": \"Executive Department Sub-Office\\/Agency\\/Bureau\",\n" +
+//             "    \"Parent_Agency\": \"United States Department of Agriculture\",\n" +
+//             "    \"Related_Agency\": \"\",\n" +
+//             "    \"Agency_Image\": \"https:\\/\\/upload.wikimedia.org\\/wikipedia\\/commons\\/thumb\\/0\\/00\\/Seal_of_the_United_States_Department_of_Agriculture.svg\\/1000px-Seal_of_the_United_States_Department_of_Agriculture.svg.png\"\n" +
+//             "  }\n" +
+//             "]";
+//
+//     @Rule
+//     public Neo4jRule neo4j = new Neo4jRule();
+//
+//     @Test
+//     public void shouldCreateADocumentNodeFromJson() {
+//         CreateNodesFromJson testClass = new CreateNodesFromJson();
+//         try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
+//
+//             NullLog log = NullLog.getInstance();
+//
+//             Util.Outgoing expected = new Util.Outgoing(8, 12, 51);
+//             Util.Outgoing actual = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
+//             Util.Outgoing duplicate = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
+//
+//             assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
+//             assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
+//             assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
+//             assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
+//             assertEquals("Should find 1 document node", 1, count(tx.findNodes(Label.label( "Document" ))));
+//             assertEquals("Should find 5 topic nodes", 5, count(tx.findNodes(Label.label( "Topic" ))));
+//
+//             tx.commit();
+//         }
+//     }
+//
+//     @Test
+//     public void shouldCreateAEntityNodeFromJson() {
+//         CreateNodesFromJson testClass = new CreateNodesFromJson();
+//         try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
+//
+//             NullLog log = NullLog.getInstance();
+//
+//             Util.Outgoing expected = new Util.Outgoing(3, 3, 12);
+//             Util.Outgoing actual = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
+//             Util.Outgoing duplicate = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
+//
+//             assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
+//             assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
+//             assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
+//             assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
+//             assertEquals("Should find 3 entity nodes", 3, count(tx.findNodes(Label.label( "Entity" ))));
+//
+//             tx.commit();
+//         }
+//     }
+// }

--- a/src/test/java/policy/ingest/CreateNodesFromJsonTest.java
+++ b/src/test/java/policy/ingest/CreateNodesFromJsonTest.java
@@ -1,82 +1,82 @@
-// package policy.ingest;
-//
-// import org.neo4j.graphdb.Label;
-// import org.neo4j.logging.NullLog;
-//
-// import org.junit.Test;
-// import org.neo4j.graphdb.Transaction;
-// import org.neo4j.harness.junit.rule.Neo4jRule;
-// import static org.neo4j.internal.helpers.collection.Iterators.count;
-//
-// import org.junit.Rule;
-// import policy.utils.Util;
-//
-// import static org.junit.Assert.assertEquals;
-//
-// public class CreateNodesFromJsonTest {
-//
-//     static String testDocumentJson = "{\"id\": \"AGO 1976-02.pdf_0\", \"doc_num\": \"1976-02\", \"doc_type\": \"AGO\", \"display_title_s\": \"AGO 1976-02 HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"display_org_s\": \"US Army\", \"display_doc_type_s\": \"Document\", \"ref_list\": [\"Executive Order 10600\", \"Executive Order 11046\", \"AR 672-5-1\", \"AR 672-51\", \"AR 672-3\", \"AR 672-31\", \"AR 672-3-1\"], \"access_timestamp_dt\": \"2021-04-08T15:55:09\", \"publication_date_dt\": \"1976-02-03T00:00:00\", \"crawler_used_s\": \"army_pubs\", \"source_fqdn_s\": \"armypubs.army.mil\", \"source_page_url_s\": \"https://armypubs.army.mil/ProductMaps/PubForm/Details.aspx?PUB_ID=42986\", \"download_url_s\": \"https://armypubs.army.mil/epubs/DR_pubs/DR_a/pdf/web/go7602.pdf\", \"cac_login_required_b\": false, \"title\": \"HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"keyw_5\": [\"ar 672-5\", \"weyand general\", \"warrant officer\", \"united states\", \"september sergeant\", \"outstanding service\", \"military operations\", \"headquarters company\", \"ar 6725-1\", \"air foree\"], \"filename\": \"AGO 1976-02.pdf\", \"summary_30\": \"fantry, United States Army, for action on 8 February 1968, while a member United States Army, for action on 18 June 1969, while a member of 3d Squad-\", \"type\": \"document\", \"page_count\": 6, \"topics_rs\": {\"award\": 0.25557929273822744, \"samae\": 0.25054542619282344, \"provisions\": 0.1844819893206493, \"heroism\": 0.17931940799917018, \"detaciiment\": 0.16559304007920778}, \"init_date\": \"NA\", \"change_date\": \"NA\", \"author\": \"NA\", \"signature\": \"NA\", \"subject\": \"NA\", \"classification\": \"NA\", \"group_s\": \"AGO 1976-02.pdf_0\", \"pagerank_r\": 3.509842455928412e-05, \"kw_doc_score_r\": null, \"version_hash_s\": \"bb39c1a3cd42a771ee1123efb46052a55f939b9b66be2a452fcc5fea39d51b29\", \"is_revoked_b\": false, \"entities\": {\"entityPars\": {\"United States Army\": [1, 2, 3, 4, 5, 6]}, \"entityCounts\": {\"United States Army\": 6}}}";
-//
-//     static String testEntitiesJson = "[\n" +
-//             "  {\n" +
-//             "    \"Agency_Aliases\": \"NAL\",\n" +
-//             "    \"Agency_Name\": \"National Agricultural Library\",\n" +
-//             "    \"Website\": \"https:\\/\\/www.nal.usda.gov\\/main\\/\",\n" +
-//             "    \"Address\": \"10301 Baltimore Ave. \\nBeltsville, MD 20705\",\n" +
-//             "    \"Email\": \"\",\n" +
-//             "    \"Phone\": \"1-301-504-5755\",\n" +
-//             "    \"TTY\": \"\",\n" +
-//             "    \"TollFree\": \"\",\n" +
-//             "    \"Government_Branch\": \"Executive Department Sub-Office\\/Agency\\/Bureau\",\n" +
-//             "    \"Parent_Agency\": \"United States Department of Agriculture\",\n" +
-//             "    \"Related_Agency\": \"\",\n" +
-//             "    \"Agency_Image\": \"https:\\/\\/upload.wikimedia.org\\/wikipedia\\/commons\\/thumb\\/0\\/00\\/Seal_of_the_United_States_Department_of_Agriculture.svg\\/1000px-Seal_of_the_United_States_Department_of_Agriculture.svg.png\"\n" +
-//             "  }\n" +
-//             "]";
-//
-//     @Rule
-//     public Neo4jRule neo4j = new Neo4jRule();
-//
-//     @Test
-//     public void shouldCreateADocumentNodeFromJson() {
-//         CreateNodesFromJson testClass = new CreateNodesFromJson();
-//         try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
-//
-//             NullLog log = NullLog.getInstance();
-//
-//             Util.Outgoing expected = new Util.Outgoing(8, 12, 51);
-//             Util.Outgoing actual = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
-//             Util.Outgoing duplicate = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
-//
-//             assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
-//             assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
-//             assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
-//             assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
-//             assertEquals("Should find 1 document node", 1, count(tx.findNodes(Label.label( "Document" ))));
-//             assertEquals("Should find 5 topic nodes", 5, count(tx.findNodes(Label.label( "Topic" ))));
-//
-//             tx.commit();
-//         }
-//     }
-//
-//     @Test
-//     public void shouldCreateAEntityNodeFromJson() {
-//         CreateNodesFromJson testClass = new CreateNodesFromJson();
-//         try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
-//
-//             NullLog log = NullLog.getInstance();
-//
-//             Util.Outgoing expected = new Util.Outgoing(3, 3, 12);
-//             Util.Outgoing actual = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
-//             Util.Outgoing duplicate = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
-//
-//             assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
-//             assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
-//             assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
-//             assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
-//             assertEquals("Should find 3 entity nodes", 3, count(tx.findNodes(Label.label( "Entity" ))));
-//
-//             tx.commit();
-//         }
-//     }
-// }
+ package policy.ingest;
+
+ import org.neo4j.graphdb.Label;
+ import org.neo4j.logging.NullLog;
+
+ import org.junit.Test;
+ import org.neo4j.graphdb.Transaction;
+ import org.neo4j.harness.junit.rule.Neo4jRule;
+ import static org.neo4j.internal.helpers.collection.Iterators.count;
+
+ import org.junit.Rule;
+ import policy.utils.Util;
+
+ import static org.junit.Assert.assertEquals;
+
+ public class CreateNodesFromJsonTest {
+
+     static String testDocumentJson = "{\"id\": \"AGO 1976-02.pdf_0\", \"doc_num\": \"1976-02\", \"doc_type\": \"AGO\", \"display_title_s\": \"AGO 1976-02 HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"display_org_s\": \"US Army\", \"display_doc_type_s\": \"Document\", \"ref_list\": [\"Executive Order 10600\", \"Executive Order 11046\", \"AR 672-5-1\", \"AR 672-51\", \"AR 672-3\", \"AR 672-31\", \"AR 672-3-1\"], \"access_timestamp_dt\": \"2021-04-08T15:55:09\", \"publication_date_dt\": \"1976-02-03T00:00:00\", \"crawler_used_s\": \"army_pubs\", \"source_fqdn_s\": \"armypubs.army.mil\", \"source_page_url_s\": \"https://armypubs.army.mil/ProductMaps/PubForm/Details.aspx?PUB_ID=42986\", \"download_url_s\": \"https://armypubs.army.mil/epubs/DR_pubs/DR_a/pdf/web/go7602.pdf\", \"cac_login_required_b\": false, \"title\": \"HQDA GENERAL ORDERS (MULTITLE TITLES BY PARAGRAPHS)\", \"keyw_5\": [\"ar 672-5\", \"weyand general\", \"warrant officer\", \"united states\", \"september sergeant\", \"outstanding service\", \"military operations\", \"headquarters company\", \"ar 6725-1\", \"air foree\"], \"filename\": \"AGO 1976-02.pdf\", \"summary_30\": \"fantry, United States Army, for action on 8 February 1968, while a member United States Army, for action on 18 June 1969, while a member of 3d Squad-\", \"type\": \"document\", \"page_count\": 6, \"topics_rs\": {\"award\": 0.25557929273822744, \"samae\": 0.25054542619282344, \"provisions\": 0.1844819893206493, \"heroism\": 0.17931940799917018, \"detaciiment\": 0.16559304007920778}, \"init_date\": \"NA\", \"change_date\": \"NA\", \"author\": \"NA\", \"signature\": \"NA\", \"subject\": \"NA\", \"classification\": \"NA\", \"group_s\": \"AGO 1976-02.pdf_0\", \"pagerank_r\": 3.509842455928412e-05, \"kw_doc_score_r\": null, \"version_hash_s\": \"bb39c1a3cd42a771ee1123efb46052a55f939b9b66be2a452fcc5fea39d51b29\", \"is_revoked_b\": false, \"entities\": {\"entityPars\": {\"United States Army\": [1, 2, 3, 4, 5, 6]}, \"entityCounts\": {\"United States Army\": 6}}}";
+
+     static String testEntitiesJson = "[\n" +
+             "  {\n" +
+             "    \"Agency_Aliases\": \"NAL\",\n" +
+             "    \"Agency_Name\": \"National Agricultural Library\",\n" +
+             "    \"Website\": \"https:\\/\\/www.nal.usda.gov\\/main\\/\",\n" +
+             "    \"Address\": \"10301 Baltimore Ave. \\nBeltsville, MD 20705\",\n" +
+             "    \"Email\": \"\",\n" +
+             "    \"Phone\": \"1-301-504-5755\",\n" +
+             "    \"TTY\": \"\",\n" +
+             "    \"TollFree\": \"\",\n" +
+             "    \"Government_Branch\": \"Executive Department Sub-Office\\/Agency\\/Bureau\",\n" +
+             "    \"Parent_Agency\": \"United States Department of Agriculture\",\n" +
+             "    \"Related_Agency\": \"\",\n" +
+             "    \"Agency_Image\": \"https:\\/\\/upload.wikimedia.org\\/wikipedia\\/commons\\/thumb\\/0\\/00\\/Seal_of_the_United_States_Department_of_Agriculture.svg\\/1000px-Seal_of_the_United_States_Department_of_Agriculture.svg.png\"\n" +
+             "  }\n" +
+             "]";
+
+     @Rule
+     public Neo4jRule neo4j = new Neo4jRule();
+
+     @Test
+     public void shouldCreateADocumentNodeFromJson() {
+         CreateNodesFromJson testClass = new CreateNodesFromJson();
+         try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
+
+             NullLog log = NullLog.getInstance();
+
+             Util.Outgoing expected = new Util.Outgoing(8, 12, 52);
+             Util.Outgoing actual = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
+             Util.Outgoing duplicate = testClass.handleCreateDocumentNodesFromJson(testDocumentJson, tx, log);
+
+             assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
+             assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
+             assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
+             assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
+             assertEquals("Should find 1 document node", 1, count(tx.findNodes(Label.label( "Document" ))));
+             assertEquals("Should find 5 topic nodes", 5, count(tx.findNodes(Label.label( "Topic" ))));
+
+             tx.commit();
+         }
+     }
+
+     @Test
+     public void shouldCreateAEntityNodeFromJson() {
+         CreateNodesFromJson testClass = new CreateNodesFromJson();
+         try (Transaction tx = neo4j.defaultDatabaseService().beginTx()) {
+
+             NullLog log = NullLog.getInstance();
+
+             Util.Outgoing expected = new Util.Outgoing(3, 3, 12);
+             Util.Outgoing actual = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
+             Util.Outgoing duplicate = testClass.handleCreateEntityNodesFromJson(testEntitiesJson, tx, log);
+
+             assertEquals("The outgoing should be all 0s because its a duplicate", 0, duplicate.nodesCreated);
+             assertEquals("The outgoing should match the expected nodes created", expected.nodesCreated, actual.nodesCreated);
+             assertEquals("The outgoing should match the expected properties set", expected.propertiesSet, actual.propertiesSet);
+             assertEquals("The outgoing should match the expected relationships created", expected.relationshipsCreated, actual.relationshipsCreated);
+             assertEquals("Should find 3 entity nodes", 3, count(tx.findNodes(Label.label( "Entity" ))));
+
+             tx.commit();
+         }
+     }
+ }


### PR DESCRIPTION
**Description**
This code update adds logic when processing documents to link them to hierarchy nodes by creating `DERIVES_AUTHORITY_FROM` relationships between document and entity nodes based on the document's `display_org_s` value. Logic: If the `display_org_s` value doesn't match a node based on the `name` attribute, search through the aliases for a node that matches, otherwise create a node with the `display_org_s` field (then create a doc -> `DERIVES_AUTHORITY_FROM` -> entity relationship)

*Note:* This PR/branch is dependent upon the gamechanger-data PR: https://github.com/dod-advana/gamechanger-data/pull/241